### PR TITLE
Annotate SYMP_0000462 as ontology root with IAO_0000700

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /build/
+.DS_Store

--- a/src/ontology/symp-edit.owl
+++ b/src/ontology/symp-edit.owl
@@ -1053,6 +1053,10 @@ Declaration(AnnotationProperty(owl:deprecated))
 
 AnnotationAssertion(rdfs:label obo:IAO_0000115 "definition"^^xsd:string)
 
+# Annotation Property: obo:IAO_0000700 (has ontology root term)
+
+AnnotationAssertion(rdfs:label obo:IAO_0000700 "has ontology root term")
+
 # Annotation Property: obo:IAO_0100001 (term replaced by)
 
 AnnotationAssertion(rdfs:label obo:IAO_0100001 "term replaced by"^^xsd:string)

--- a/src/ontology/symp-edit.owl
+++ b/src/ontology/symp-edit.owl
@@ -13,6 +13,7 @@ Prefix(oboInOwl:=<http://www.geneontology.org/formats/oboInOwl#>)
 
 Ontology(<http://purl.obolibrary.org/obo/symp.owl>
 <http://purl.obolibrary.org/obo/symp/releases/2022-09-06/symp.owl>
+Annotation(obo:IAO_0000700 obo:SYMP_0000462)
 Annotation(dc:description "The Symptom Ontology has been developed as a standardized ontology for symptoms of human diseases.")
 Annotation(dc:title "Symptom Ontology")
 Annotation(terms:license <https://creativecommons.org/publicdomain/zero/1.0/>)
@@ -1023,6 +1024,7 @@ Declaration(Class(obo:SYMP_0020051))
 Declaration(Class(obo:SYMP_0020052))
 Declaration(ObjectProperty(symp:part_of))
 Declaration(AnnotationProperty(obo:IAO_0000115))
+Declaration(AnnotationProperty(obo:IAO_0000700))
 Declaration(AnnotationProperty(obo:IAO_0100001))
 Declaration(AnnotationProperty(dc:description))
 Declaration(AnnotationProperty(dc:title))


### PR DESCRIPTION
Related to https://github.com/OBOFoundry/OBOFoundry.github.io/issues/2149

## What this Does

1. Add a new annotation property [has ontology root term (IAO:0000700)](http://purl.obolibrary.org/obo/IAO_0000700) to the ontology
2. Apply this property at the ontology level to annotate [symptom (SYMP:0000462)](http://purl.obolibrary.org/obo/SYMP_0000462) as the root.

It's true that this is already logically the root element, but this makes it explicit.

## Why this is helpful

- the Ontology Lookup Service uses this to help better display ontologies
- if SYMP_0000462 ever is aligned with an upper ontology like BFO, it still will be the thing shown on OLS as the "root"
- this will be generally useful for things like alignment with COB since it makes it easier to figure out where the work will be

cc @matentzn